### PR TITLE
Fix `deploy` cmd

### DIFF
--- a/src/commands/compile/compiler.rs
+++ b/src/commands/compile/compiler.rs
@@ -69,7 +69,11 @@ pub fn compile(
     }
 }
 
-fn compile_with_zksolc(project_root: &str, contract_path: &str, contract_name: &str) -> eyre::Result<Artifact> {
+fn compile_with_zksolc(
+    project_root: &str,
+    contract_path: &str,
+    contract_name: &str,
+) -> eyre::Result<Artifact> {
     let root = PathBuf::from(project_root);
     let zk_project = ZKSProject::from(
         Project::builder()

--- a/src/commands/compile/compiler.rs
+++ b/src/commands/compile/compiler.rs
@@ -58,18 +58,19 @@ impl Artifact {
 }
 
 pub fn compile(
+    project_root: &str,
     contract_path: &str,
     contract_name: &str,
     compiler: Compiler,
 ) -> eyre::Result<Artifact> {
     match compiler {
-        Compiler::ZKSolc => compile_with_zksolc(contract_path, contract_name),
+        Compiler::ZKSolc => compile_with_zksolc(project_root, contract_path, contract_name),
         Compiler::Solc => compile_with_solc(contract_path, contract_name),
     }
 }
 
-fn compile_with_zksolc(contract_path: &str, contract_name: &str) -> eyre::Result<Artifact> {
-    let root = PathBuf::from(contract_path);
+fn compile_with_zksolc(project_root: &str, contract_path: &str, contract_name: &str) -> eyre::Result<Artifact> {
+    let root = PathBuf::from(project_root);
     let zk_project = ZKSProject::from(
         Project::builder()
             .paths(ProjectPathsConfig::builder().build_with_root(root))

--- a/src/commands/compile/mod.rs
+++ b/src/commands/compile/mod.rs
@@ -9,6 +9,8 @@ pub mod project;
 pub(crate) struct Args {
     #[clap(short, long, name = "COMPILER")]
     pub compiler: compiler::Compiler,
+    #[clap(short, long, name = "PROJECT_ROOT_PATH")]
+    pub project_root: String,
     #[clap(short, long, name = "CONTRACT_PATH")]
     pub contract_path: String,
     #[clap(short, long, name = "CONTRACT_NAME")]
@@ -16,7 +18,7 @@ pub(crate) struct Args {
 }
 
 pub(crate) async fn run(args: Args) -> eyre::Result<()> {
-    let output = compiler::compile(&args.contract_path, &args.contract_name, args.compiler);
+    let output = compiler::compile(&args.project_root, &args.contract_path, &args.contract_name, args.compiler).unwrap();
     log::info!("{output:?}");
     Ok(())
 }

--- a/src/commands/compile/mod.rs
+++ b/src/commands/compile/mod.rs
@@ -23,8 +23,7 @@ pub(crate) async fn run(args: Args) -> eyre::Result<()> {
         &args.contract_path,
         &args.contract_name,
         args.compiler,
-    )
-    .unwrap();
+    )?;
     log::info!("{output:?}");
     Ok(())
 }

--- a/src/commands/compile/mod.rs
+++ b/src/commands/compile/mod.rs
@@ -18,7 +18,13 @@ pub(crate) struct Args {
 }
 
 pub(crate) async fn run(args: Args) -> eyre::Result<()> {
-    let output = compiler::compile(&args.project_root, &args.contract_path, &args.contract_name, args.compiler).unwrap();
+    let output = compiler::compile(
+        &args.project_root,
+        &args.contract_path,
+        &args.contract_name,
+        args.compiler,
+    )
+    .unwrap();
     log::info!("{output:?}");
     Ok(())
 }

--- a/src/commands/compile/project.rs
+++ b/src/commands/compile/project.rs
@@ -39,6 +39,12 @@ impl ZKSProject {
             ZKCompilerError::CompilationError(format!("failed to execute zksolc: {e}"))
         })?;
 
+        if !command_output.stderr.is_empty() {
+            log::error!("STDERR: {}", String::from_utf8_lossy(&command_output.stderr));
+        } else {
+            log::info!("STDOUT: {}", String::from_utf8_lossy(&command_output.stdout));
+        }
+
         let compilation_output = String::from_utf8_lossy(&command_output.stdout)
             .into_owned()
             .trim()

--- a/src/commands/compile/project.rs
+++ b/src/commands/compile/project.rs
@@ -40,9 +40,15 @@ impl ZKSProject {
         })?;
 
         if !command_output.stderr.is_empty() {
-            log::error!("STDERR: {}", String::from_utf8_lossy(&command_output.stderr));
+            log::error!(
+                "STDERR: {}",
+                String::from_utf8_lossy(&command_output.stderr)
+            );
         } else {
-            log::info!("STDOUT: {}", String::from_utf8_lossy(&command_output.stdout));
+            log::info!(
+                "STDOUT: {}",
+                String::from_utf8_lossy(&command_output.stdout)
+            );
         }
 
         let compilation_output = String::from_utf8_lossy(&command_output.stdout)

--- a/src/commands/deploy.rs
+++ b/src/commands/deploy.rs
@@ -11,6 +11,8 @@ use zksync_web3_rs::{providers::Provider, signers::Signer};
 
 #[derive(ClapArgs)]
 pub(crate) struct Args {
+    #[clap(short, long, name = "PROJECT_ROOT_PATH")]
+    pub project_root: String,
     #[clap(
         long,
         name = "CONTRACT PATH",
@@ -49,6 +51,7 @@ pub(crate) async fn run(args: Args, config: ZKSyncConfig) -> eyre::Result<()> {
             .await?
     } else if let Some(contract_path) = args.contract.clone() {
         let artifact = compile::compiler::compile(
+            &args.project_root,
             &contract_path,
             &args.contract_name.context("no contract name provided")?,
             compile::compiler::Compiler::ZKSolc,


### PR DESCRIPTION
## Changes

- Adding `--project-root` path for `deploy` cmd. This is for projects that require more than one contract to be compiled for its proper deployment. It also solves an issue when finding the contract in that case: before, if you'd pass the project's root path to `--contract`, then that path would be concatenated to `:contract_name` so the contract that you were looking to deploy was never going to be found.
- Adding `--project-root` path for `compile` cmd. Only for `zksolc` compilations, I'll file an issue for supporting this for `solc` compilations.