### PR TITLE
Fix `call` & `send` argument overlapping

### DIFF
--- a/src/commands/call.rs
+++ b/src/commands/call.rs
@@ -44,10 +44,15 @@ pub(crate) async fn run(args: Args, config: ZKSyncConfig) -> eyre::Result<()> {
     } else {
         // Note: CLI syntactic sugar need to be handle in the run() function.
         // If more sugar cases are needed, we should switch to a match statement.
-        let function_signature = if args.function.clone().unwrap().is_empty() {
+        let function_signature = if args
+            .function
+            .clone()
+            .context("No function signature provided")?
+            .is_empty()
+        {
             "function()"
         } else {
-            func = args.function.unwrap();
+            func = args.function.context("No function signature provided")?;
             &func
         };
 
@@ -80,7 +85,7 @@ pub(crate) async fn run(args: Args, config: ZKSyncConfig) -> eyre::Result<()> {
             // The contract to call is a regular contract without arguments.
             (false, false) => function.short_signature().into(),
         };
-    
+
         request = request.data(data);
     }
 

--- a/src/commands/call.rs
+++ b/src/commands/call.rs
@@ -15,9 +15,9 @@ pub const ERA_IN_MEMORY_NODE_CHAIN_ID: u16 = 260;
 pub(crate) struct Args {
     #[clap(short, long, name = "CONTRACT_ADDRESS")]
     pub contract: Address,
-    #[clap(short, long, name = "FUNCTION_SIGNATURE")]
-    pub function: String,
-    #[clap(short, long, num_args(1..), name = "FUNCTION_ARGS")]
+    #[clap(short, long, name = "FUNCTION_SIGNATURE", conflicts_with = "data")]
+    pub function: Option<String>,
+    #[clap(short, long, num_args(1..), name = "FUNCTION_ARGS", conflicts_with = "data")]
     pub args: Option<Vec<String>>,
     #[clap(long, name = "DATA")]
     pub data: Option<Bytes>,
@@ -38,53 +38,55 @@ pub(crate) async fn run(args: Args, config: ZKSyncConfig) -> eyre::Result<()> {
         Provider::try_from(format!("{host}", host = config.host,))?
     };
 
-    // Note: CLI syntactic sugar need to be handle in the run() function.
-    // If more sugar cases are needed, we should switch to a match statement.
-    let function_signature = if args.function.is_empty() {
-        "function()"
-    } else {
-        &args.function
-    };
-
     let mut request = Eip1559TransactionRequest::new()
         .to(args.contract)
         .chain_id(args.chain_id);
 
+    let func: String;
     if let Some(data) = args.data {
         request = request.data(data);
+    } else {
+        // Note: CLI syntactic sugar need to be handle in the run() function.
+        // If more sugar cases are needed, we should switch to a match statement.
+        let function_signature = if args.function.clone().unwrap().is_empty() {
+            "function()"
+        } else {
+            func = args.function.unwrap();
+            &func
+        };
+
+        let function = if args.contract == zks_utils::ECADD_PRECOMPILE_ADDRESS {
+            zks_utils::ec_add_function()
+        } else if args.contract == zks_utils::ECMUL_PRECOMPILE_ADDRESS {
+            zks_utils::ec_mul_function()
+        } else if args.contract == zks_utils::MODEXP_PRECOMPILE_ADDRESS {
+            zks_utils::mod_exp_function()
+        } else {
+            HumanReadableParser::parse_function(function_signature)?
+        };
+
+        let function_args = if let Some(function_args) = args.args {
+            function.decode_input(&zks_utils::encode_args(&function, &function_args)?)?
+        } else {
+            vec![]
+        };
+
+        let data = match (
+            !function_args.is_empty(),
+            zks_utils::is_precompile(args.contract),
+        ) {
+            // The contract to call is a precompile with arguments.
+            (true, true) => encode(&function_args),
+            // The contract to call is a regular contract with arguments.
+            (true, false) => function.encode_input(&function_args)?,
+            // The contract to call is a precompile without arguments.
+            (false, true) => Default::default(),
+            // The contract to call is a regular contract without arguments.
+            (false, false) => function.short_signature().into(),
+        };
+    
+        request = request.data(data);
     }
-
-    let function = if args.contract == zks_utils::ECADD_PRECOMPILE_ADDRESS {
-        zks_utils::ec_add_function()
-    } else if args.contract == zks_utils::ECMUL_PRECOMPILE_ADDRESS {
-        zks_utils::ec_mul_function()
-    } else if args.contract == zks_utils::MODEXP_PRECOMPILE_ADDRESS {
-        zks_utils::mod_exp_function()
-    } else {
-        HumanReadableParser::parse_function(function_signature)?
-    };
-
-    let function_args = if let Some(function_args) = args.args {
-        function.decode_input(&zks_utils::encode_args(&function, &function_args)?)?
-    } else {
-        vec![]
-    };
-
-    let data = match (
-        !function_args.is_empty(),
-        zks_utils::is_precompile(args.contract),
-    ) {
-        // The contract to call is a precompile with arguments.
-        (true, true) => encode(&function_args),
-        // The contract to call is a regular contract with arguments.
-        (true, false) => function.encode_input(&function_args)?,
-        // The contract to call is a precompile without arguments.
-        (false, true) => Default::default(),
-        // The contract to call is a regular contract without arguments.
-        (false, false) => function.short_signature().into(),
-    };
-
-    request = request.data(data);
 
     let transaction: TypedTransaction = request.into();
 

--- a/src/commands/send.rs
+++ b/src/commands/send.rs
@@ -48,10 +48,15 @@ pub(crate) async fn run(args: Args, config: ZKSyncConfig) -> eyre::Result<()> {
     } else if let Some(function_args) = args.args {
         // Note: CLI syntactic sugar need to be handle in the run() function.
         // If more sugar cases are needed, we should switch to a match statement.
-        let function_signature = if args.function.clone().unwrap().is_empty() {
+        let function_signature = if args
+            .function
+            .clone()
+            .context("No function signature provided")?
+            .is_empty()
+        {
             "function()"
         } else {
-            func = args.function.unwrap();
+            func = args.function.context("No function signature provided")?;
             &func
         };
 

--- a/src/commands/send.rs
+++ b/src/commands/send.rs
@@ -14,9 +14,9 @@ use zksync_web3_rs::{providers::Provider, types::Address};
 pub(crate) struct Args {
     #[clap(short, long, name = "CONTRACT_ADDRESS")]
     pub contract: Address,
-    #[clap(short, long, name = "FUNCTION_SIGNATURE")]
-    pub function: String,
-    #[clap(short, long, num_args(1..), name = "FUNCTION_ARGS")]
+    #[clap(short, long, name = "FUNCTION_SIGNATURE", conflicts_with = "data")]
+    pub function: Option<String>,
+    #[clap(short, long, num_args(1..), name = "FUNCTION_ARGS", conflicts_with = "data")]
     pub args: Option<Vec<String>>,
     #[clap(long, name = "DATA")]
     pub data: Option<Bytes>,
@@ -40,23 +40,25 @@ pub(crate) async fn run(args: Args, config: ZKSyncConfig) -> eyre::Result<()> {
     }
     .interval(std::time::Duration::from_millis(10));
 
-    // Note: CLI syntactic sugar need to be handle in the run() function.
-    // If more sugar cases are needed, we should switch to a match statement.
-    let function_signature = if args.function.is_empty() {
-        "function()"
-    } else {
-        &args.function
-    };
-
     let sender = args.private_key.with_chain_id(args.chain_id);
 
     let mut request = Eip712TransactionRequest::new()
         .r#type(zks_utils::EIP712_TX_TYPE)
         .to(args.contract);
 
+    let func: String;
     if let Some(data) = args.data {
         request = request.data(data);
     } else if let Some(function_args) = args.args {
+        // Note: CLI syntactic sugar need to be handle in the run() function.
+        // If more sugar cases are needed, we should switch to a match statement.
+        let function_signature = if args.function.clone().unwrap().is_empty() {
+            "function()"
+        } else {
+            func = args.function.unwrap();
+            &func
+        };
+
         let function = if args.contract == zks_utils::ECADD_PRECOMPILE_ADDRESS {
             zks_utils::ec_add_function()
         } else if args.contract == zks_utils::ECMUL_PRECOMPILE_ADDRESS {

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,6 +4,8 @@ use zksync_era_cli::cli;
 async fn main() {
     env_logger::builder()
         .filter_module("reqwest::connect", log::LevelFilter::Off)
+        .filter_module("rustls::client", log::LevelFilter::Off)
+        .filter_module("rustls::common_state", log::LevelFilter::Off)
         .filter_level(log::LevelFilter::Debug)
         .init();
 


### PR DESCRIPTION
There should be two possible use cases of `send` and `call`:
1. Sending the function signature with the arguments separately
2. Sending the calldata