### PR TITLE
feat(proof-time): add batch-details cmd

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -25,18 +25,12 @@ dependencies = [
 
 [[package]]
 name = "addr2line"
-version = "0.22.0"
+version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e4503c46a5c0c7844e948c9a4d6acd9f50cccb4de1c48eb9e291ea17470c678"
+checksum = "f5fb1d8e4442bd405fdfd1dacb42792696b0cf9cb15882e5d097b742a676d375"
 dependencies = [
  "gimli",
 ]
-
-[[package]]
-name = "adler"
-version = "1.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
 
 [[package]]
 name = "adler2"
@@ -160,9 +154,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.86"
+version = "1.0.87"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3d1d046238990b9cf5bcde22a3fb3584ee5cf65fb2765f454ed428c7a0063da"
+checksum = "10f00e1f6e58a40e807377c75c6a7f97bf9044fab57816f2414e6f5f4499d7b8"
 
 [[package]]
 name = "arr_macro"
@@ -299,9 +293,9 @@ checksum = "0c4b4d0bd25bd0b74681c0ad21497610ce1b7c91b1022cd21c80c6fbdd9476b0"
 
 [[package]]
 name = "aws-lc-rs"
-version = "1.8.1"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ae74d9bd0a7530e8afd1770739ad34b36838829d6ad61818f9230f683f5ad77"
+checksum = "2f95446d919226d587817a7d21379e6eb099b97b45110a7f272a444ca5c54070"
 dependencies = [
  "aws-lc-sys",
  "mirai-annotations",
@@ -311,9 +305,9 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-sys"
-version = "0.20.1"
+version = "0.21.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f0e249228c6ad2d240c2dc94b714d711629d52bad946075d8e9b2f5391f0703"
+checksum = "234314bd569802ec87011d653d6815c6d7b9ffb969e9fee5b8b20ef860e8dce9"
 dependencies = [
  "bindgen",
  "cc",
@@ -373,17 +367,17 @@ dependencies = [
 
 [[package]]
 name = "backtrace"
-version = "0.3.73"
+version = "0.3.74"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5cc23269a4f8976d0a4d2e7109211a419fe30e8d88d677cd60b6bc79c5732e0a"
+checksum = "8d82cb332cdfaed17ae235a638438ac4d4839913cc2af585c3c6746e8f8bee1a"
 dependencies = [
  "addr2line",
- "cc",
  "cfg-if 1.0.0",
  "libc",
- "miniz_oxide 0.7.4",
+ "miniz_oxide",
  "object",
  "rustc-demangle",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -884,9 +878,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.1.16"
+version = "1.1.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9d013ecb737093c0e86b151a7b837993cf9ec6c502946cfb44bedc392421e0b"
+checksum = "b62ac837cdb5cb22e10a256099b4fc502b1dfe560cb282963a974d7abd80e476"
 dependencies = [
  "jobserver",
  "libc",
@@ -967,38 +961,38 @@ dependencies = [
 
 [[package]]
 name = "circuit_encodings"
-version = "0.140.1"
+version = "0.140.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8438d7af992b730143b679e2c6938cb9e0193897ecaf668c59189af8ac296b7"
+checksum = "cf6b7cc842eadb4c250cdc6a8bc1dd97624d9f08bbe54db3e11fb23c3a72be07"
 dependencies = [
  "derivative",
  "serde",
  "zk_evm 0.140.0",
- "zkevm_circuits 0.140.2",
+ "zkevm_circuits 0.140.3",
 ]
 
 [[package]]
 name = "circuit_encodings"
-version = "0.141.1"
+version = "0.141.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01a2fcc80e97682104f355dd819cb4972583828a6c0f65ec26889a78a84b0c56"
+checksum = "7898ffbf3cd413576b4b674fe1545a35488c67eb16bd5a4148425e42c2a2b65b"
 dependencies = [
  "derivative",
  "serde",
  "zk_evm 0.141.0",
- "zkevm_circuits 0.141.1",
+ "zkevm_circuits 0.141.2",
 ]
 
 [[package]]
 name = "circuit_encodings"
-version = "0.142.1"
+version = "0.142.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94be7afb5ace6024d6e3c105d521b4b9b563bac14a92c2f59c4683e9169a25d8"
+checksum = "8364ecafcc4b2c896023f8d3af952c52a500aa55f14fd268bb5d9ab07f837369"
 dependencies = [
  "derivative",
  "serde",
  "zk_evm 0.141.0",
- "zkevm_circuits 0.141.1",
+ "zkevm_circuits 0.141.2",
 ]
 
 [[package]]
@@ -1015,57 +1009,57 @@ dependencies = [
 
 [[package]]
 name = "circuit_sequencer_api"
-version = "0.133.0"
+version = "0.133.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a87dc7bee6630d4954ac7982eb77e2007476662250cf18e5c460bbc5ee435f1"
+checksum = "eb959b1f8c6bbd8be711994d182e85452a26a5d2213a709290b71c8262af1331"
 dependencies = [
- "bellman_ce 0.7.0",
  "derivative",
  "rayon",
  "serde",
  "zk_evm 0.133.0",
+ "zksync_bellman",
 ]
 
 [[package]]
 name = "circuit_sequencer_api"
-version = "0.140.1"
+version = "0.140.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d9b15463f9da44561867e6416a5b9c343164636811f68503868d37675be2d59"
+checksum = "fa5f22311ce609d852d7d9f4943535ea4610aeb785129ae6ff83d5201c4fb387"
 dependencies = [
- "bellman_ce 0.8.0",
- "circuit_encodings 0.140.1",
+ "circuit_encodings 0.140.3",
  "derivative",
  "rayon",
  "serde",
  "zk_evm 0.140.0",
+ "zksync_bellman",
 ]
 
 [[package]]
 name = "circuit_sequencer_api"
-version = "0.141.1"
+version = "0.141.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55a257b31a8ea1c1723cab4fb5661c6b4c0ebe022d4b73bea9eb7c9150bd3bc1"
+checksum = "4c47c71d6ba83a8beb0af13af70beffd627f5497caf3d44c6f96363e788b07ea"
 dependencies = [
- "bellman_ce 0.8.0",
- "circuit_encodings 0.141.1",
+ "circuit_encodings 0.141.2",
  "derivative",
  "rayon",
  "serde",
  "zk_evm 0.141.0",
+ "zksync_bellman",
 ]
 
 [[package]]
 name = "circuit_sequencer_api"
-version = "0.142.1"
+version = "0.142.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "273351e61b0f9a36b09550e244989c38f9877382b42d0329797c72004dcabef7"
+checksum = "e264723359e6a1aad98110bdccf1ae3ad596e93e7d31da9e40f6adc07e4add54"
 dependencies = [
- "bellman_ce 0.8.0",
- "circuit_encodings 0.142.1",
+ "circuit_encodings 0.142.2",
  "derivative",
  "rayon",
  "serde",
  "zk_evm 0.141.0",
+ "zksync_bellman",
 ]
 
 [[package]]
@@ -2420,7 +2414,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "324a1be68054ef05ad64b861cc9eaf1d623d2d8cb25b4bf2cb9cdd902b4bf253"
 dependencies = [
  "crc32fast",
- "miniz_oxide 0.8.0",
+ "miniz_oxide",
 ]
 
 [[package]]
@@ -2681,9 +2675,9 @@ dependencies = [
 
 [[package]]
 name = "gimli"
-version = "0.29.0"
+version = "0.31.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40ecd4077b5ae9fd2e9e169b102c6c330d0605168eb0e8bf79952b256dbefffd"
+checksum = "32085ea23f3234fc7846555e85283ba4de91e21016dc0455a16286d87a292d64"
 
 [[package]]
 name = "glob"
@@ -3118,7 +3112,7 @@ dependencies = [
  "hyper 1.4.1",
  "hyper-util",
  "log",
- "rustls 0.23.12",
+ "rustls 0.23.13",
  "rustls-pki-types",
  "tokio",
  "tokio-rustls 0.26.0",
@@ -3169,9 +3163,9 @@ dependencies = [
 
 [[package]]
 name = "hyper-util"
-version = "0.1.7"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cde7055719c54e36e95e8719f95883f22072a48ede39db7fc17a4e1d5281e9b9"
+checksum = "da62f120a8a37763efb0cf8fdf264b884c7b8b9ac8660b900c8661030c00e6ba"
 dependencies = [
  "bytes",
  "futures-channel",
@@ -3310,9 +3304,9 @@ dependencies = [
 
 [[package]]
 name = "ipnet"
-version = "2.9.0"
+version = "2.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f518f335dce6725a761382244631d86cf0ccb2863413590b31338feb467f9c3"
+checksum = "187674a687eed5fe42285b40c6291f9a01517d415fad1c3cbc6a9f778af7fcd4"
 
 [[package]]
 name = "ipnetwork"
@@ -3438,7 +3432,7 @@ dependencies = [
  "http 1.1.0",
  "jsonrpsee-core",
  "pin-project",
- "rustls 0.23.12",
+ "rustls 0.23.13",
  "rustls-pki-types",
  "rustls-platform-verifier",
  "soketto",
@@ -3491,7 +3485,7 @@ dependencies = [
  "hyper-util",
  "jsonrpsee-core",
  "jsonrpsee-types",
- "rustls 0.23.12",
+ "rustls 0.23.13",
  "rustls-platform-verifier",
  "serde",
  "serde_json",
@@ -3854,15 +3848,6 @@ name = "minimal-lexical"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
-
-[[package]]
-name = "miniz_oxide"
-version = "0.7.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8a240ddb74feaf34a79a7add65a741f3167852fba007066dcac1ca548d89c08"
-dependencies = [
- "adler",
-]
 
 [[package]]
 name = "miniz_oxide"
@@ -5486,16 +5471,16 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.12"
+version = "0.23.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c58f8c84392efc0a126acce10fa59ff7b3d2ac06ab451a33f2741989b806b044"
+checksum = "f2dabaac7466917e566adb06783a81ca48944c6898a1b08b9374106dd671f4c8"
 dependencies = [
  "aws-lc-rs",
  "log",
  "once_cell",
  "ring 0.17.8",
  "rustls-pki-types",
- "rustls-webpki 0.102.7",
+ "rustls-webpki 0.102.8",
  "subtle",
  "zeroize",
 ]
@@ -5549,10 +5534,10 @@ dependencies = [
  "jni",
  "log",
  "once_cell",
- "rustls 0.23.12",
+ "rustls 0.23.13",
  "rustls-native-certs",
  "rustls-platform-verifier-android",
- "rustls-webpki 0.102.7",
+ "rustls-webpki 0.102.8",
  "security-framework",
  "security-framework-sys",
  "webpki-roots 0.26.5",
@@ -5577,9 +5562,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.102.7"
+version = "0.102.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84678086bd54edf2b415183ed7a94d0efb049f1b646a33e22a36f3794be6ae56"
+checksum = "64ca1bc8749bd4cf37b5ce386cc146580777b4e8572c7b97baf22c83f444bee9"
 dependencies = [
  "aws-lc-rs",
  "ring 0.17.8",
@@ -5643,11 +5628,11 @@ dependencies = [
 
 [[package]]
 name = "schannel"
-version = "0.1.23"
+version = "0.1.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fbc91545643bcf3a0bbb6569265615222618bdf33ce4ffbbd13c4bbd4c093534"
+checksum = "e9aaafd5a2b6e3d657ff009d82fbd630b6bd54dd4eb06f21693925cdf80f9b8b"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -5900,9 +5885,9 @@ checksum = "a3f0bf26fd526d2a95683cd0f87bf103b8539e2ca1ef48ce002d67aad59aa0b4"
 
 [[package]]
 name = "serde"
-version = "1.0.209"
+version = "1.0.210"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99fce0ffe7310761ca6bf9faf5115afbc19688edd00171d81b1bb1b116c63e09"
+checksum = "c8e3592472072e6e22e0a54d5904d9febf8508f65fb8552499a1abc7d1078c3a"
 dependencies = [
  "serde_derive",
 ]
@@ -5919,9 +5904,9 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.209"
+version = "1.0.210"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5831b979fd7b5439637af1752d535ff49f4860c0f341d1baeb6faf0f4242170"
+checksum = "243902eda00fad750862fc144cea25caca5e20d615af0a81bee94ca738f1df1f"
 dependencies = [
  "proc-macro2 1.0.86",
  "quote 1.0.37",
@@ -6271,9 +6256,9 @@ checksum = "c85070f382340e8b23a75808e83573ddf65f9ad9143df9573ca37c1ed2ee956a"
 
 [[package]]
 name = "sqlformat"
-version = "0.2.4"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f895e3734318cc55f1fe66258926c9b910c124d47520339efecbb6c59cec7c1f"
+checksum = "7bba3a93db0cc4f7bdece8bb09e77e2e785c20bfebf79eb8340ed80708048790"
 dependencies = [
  "nom",
  "unicode_categories",
@@ -6864,7 +6849,7 @@ version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c7bc40d0e5a97695bb96e27995cd3a08538541b0a846f65bba7a359f36700d4"
 dependencies = [
- "rustls 0.23.12",
+ "rustls 0.23.13",
  "rustls-pki-types",
  "tokio",
 ]
@@ -7883,20 +7868,6 @@ name = "zeroize"
 version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ced3678a2879b30306d323f4542626697a464a97c0a07c9aebf7ebca65cd4dde"
-dependencies = [
- "zeroize_derive",
-]
-
-[[package]]
-name = "zeroize_derive"
-version = "1.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
-dependencies = [
- "proc-macro2 1.0.86",
- "quote 1.0.37",
- "syn 2.0.77",
-]
 
 [[package]]
 name = "zip"
@@ -8040,14 +8011,13 @@ dependencies = [
 
 [[package]]
 name = "zkevm_circuits"
-version = "0.140.2"
+version = "0.140.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8beed4cc1ab1f9d99a694506d18705e10059534b30742832be49637c4775e1f8"
+checksum = "e3c365c801e0c6eda83fbd153df45575172beb406bfb663d386f9154b4325eda"
 dependencies = [
  "arrayvec 0.7.6",
  "bincode",
  "boojum 0.30.1",
- "cs_derive",
  "derivative",
  "hex",
  "itertools 0.10.5",
@@ -8058,18 +8028,18 @@ dependencies = [
  "serde_json",
  "smallvec",
  "zkevm_opcode_defs 0.132.0",
+ "zksync_cs_derive",
 ]
 
 [[package]]
 name = "zkevm_circuits"
-version = "0.141.1"
+version = "0.141.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20f1a64d256cc5f5c58d19cf976cb45973df54e4e3010ca4a3e6fafe9f06075e"
+checksum = "2ccd0352e122a4e6f0046d2163b7e692e627b23fc3264faa77331a21b65833fd"
 dependencies = [
  "arrayvec 0.7.6",
  "bincode",
  "boojum 0.30.1",
- "cs_derive",
  "derivative",
  "hex",
  "itertools 0.10.5",
@@ -8080,6 +8050,7 @@ dependencies = [
  "serde_json",
  "smallvec",
  "zkevm_opcode_defs 0.141.0",
+ "zksync_cs_derive",
 ]
 
 [[package]]
@@ -8193,7 +8164,7 @@ dependencies = [
 [[package]]
 name = "zksync-ethers-rs"
 version = "0.1.1"
-source = "git+https://github.com/lambdaclass/zksync-web3-rs?branch=zksync-ethers-rs-v1#904dfa6021b0bb70c9e52d06b7a583d1370b22bf"
+source = "git+https://github.com/lambdaclass/zksync-web3-rs?branch=zksync-ethers-rs-v1#dd28f08abe2c16dd5d222c9859764f7a4ff00507"
 dependencies = [
  "async-trait",
  "clap",
@@ -8218,7 +8189,7 @@ dependencies = [
 [[package]]
 name = "zksync_basic_types"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-era.git#4d8862b76a55ac78edd481694fefd2107736ffd9"
+source = "git+https://github.com/matter-labs/zksync-era.git#946877f98d0448938a9c6030b0986346e5d93218"
 dependencies = [
  "anyhow",
  "chrono",
@@ -8235,10 +8206,33 @@ dependencies = [
 ]
 
 [[package]]
-name = "zksync_concurrency"
-version = "0.1.0-rc.11"
+name = "zksync_bellman"
+version = "0.30.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0e31a9fc9a390b440cd12bbe040330dc64f64697a8a8ecbc3beb98cd0747909"
+checksum = "5ffa03efe9bdb137a4b36b97d1a74237e18c9ae42b755163d903a9d48c1a5d80"
+dependencies = [
+ "arrayvec 0.7.6",
+ "bit-vec",
+ "blake2s_simd",
+ "byteorder",
+ "cfg-if 1.0.0",
+ "crossbeam 0.8.4",
+ "futures",
+ "hex",
+ "lazy_static",
+ "num_cpus",
+ "rand 0.4.6",
+ "serde",
+ "smallvec",
+ "tiny-keccak 1.5.0",
+ "zksync_pairing",
+]
+
+[[package]]
+name = "zksync_concurrency"
+version = "0.1.0-rc.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a49ad68bfaf6fb8542c68894b68b28be31514786549855aaa8a46b36defbb100"
 dependencies = [
  "anyhow",
  "once_cell",
@@ -8256,7 +8250,7 @@ dependencies = [
 [[package]]
 name = "zksync_config"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-era.git#4d8862b76a55ac78edd481694fefd2107736ffd9"
+source = "git+https://github.com/matter-labs/zksync-era.git#946877f98d0448938a9c6030b0986346e5d93218"
 dependencies = [
  "anyhow",
  "rand 0.8.5",
@@ -8271,9 +8265,9 @@ dependencies = [
 
 [[package]]
 name = "zksync_consensus_utils"
-version = "0.1.0-rc.11"
+version = "0.1.0-rc.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ff679f8b5f671d887a750b8107f3b5c01fd6085f68eef37ab01de8d2bd0736b"
+checksum = "4d624f55e2449f43b2c85588b5dd2a28b3c5ea629effc89df76e3254f8d9d2fb"
 dependencies = [
  "anyhow",
  "rand 0.8.5",
@@ -8284,7 +8278,7 @@ dependencies = [
 [[package]]
 name = "zksync_contracts"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-era.git#4d8862b76a55ac78edd481694fefd2107736ffd9"
+source = "git+https://github.com/matter-labs/zksync-era.git#946877f98d0448938a9c6030b0986346e5d93218"
 dependencies = [
  "envy",
  "ethabi",
@@ -8298,7 +8292,7 @@ dependencies = [
 [[package]]
 name = "zksync_crypto_primitives"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-era.git#4d8862b76a55ac78edd481694fefd2107736ffd9"
+source = "git+https://github.com/matter-labs/zksync-era.git#946877f98d0448938a9c6030b0986346e5d93218"
 dependencies = [
  "anyhow",
  "blake2 0.10.6",
@@ -8356,7 +8350,7 @@ dependencies = [
 [[package]]
 name = "zksync_mini_merkle_tree"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-era.git#4d8862b76a55ac78edd481694fefd2107736ffd9"
+source = "git+https://github.com/matter-labs/zksync-era.git#946877f98d0448938a9c6030b0986346e5d93218"
 dependencies = [
  "once_cell",
  "zksync_basic_types",
@@ -8366,13 +8360,13 @@ dependencies = [
 [[package]]
 name = "zksync_multivm"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-era.git#4d8862b76a55ac78edd481694fefd2107736ffd9"
+source = "git+https://github.com/matter-labs/zksync-era.git#946877f98d0448938a9c6030b0986346e5d93218"
 dependencies = [
  "anyhow",
- "circuit_sequencer_api 0.133.0",
- "circuit_sequencer_api 0.140.1",
- "circuit_sequencer_api 0.141.1",
- "circuit_sequencer_api 0.142.1",
+ "circuit_sequencer_api 0.133.1",
+ "circuit_sequencer_api 0.140.3",
+ "circuit_sequencer_api 0.141.2",
+ "circuit_sequencer_api 0.142.2",
  "circuit_sequencer_api 0.150.4",
  "hex",
  "itertools 0.10.5",
@@ -8397,7 +8391,7 @@ dependencies = [
 [[package]]
 name = "zksync_object_store"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-era.git#4d8862b76a55ac78edd481694fefd2107736ffd9"
+source = "git+https://github.com/matter-labs/zksync-era.git#946877f98d0448938a9c6030b0986346e5d93218"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8433,9 +8427,9 @@ dependencies = [
 
 [[package]]
 name = "zksync_protobuf"
-version = "0.1.0-rc.11"
+version = "0.1.0-rc.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4f6ba3bf0aac20de18b4ae18a22d8c81b83f8f72e8fdec1c879525ecdacd2f5"
+checksum = "d26fb2beb3aeafb5e9babf1acf6494662cc7157b893fa248bd151494f931d07f"
 dependencies = [
  "anyhow",
  "bit-vec",
@@ -8454,9 +8448,9 @@ dependencies = [
 
 [[package]]
 name = "zksync_protobuf_build"
-version = "0.1.0-rc.11"
+version = "0.1.0-rc.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7798c248b9a64505f0586bd5fadad6b26c999be4a8dec6b1a86b10b3888169c5"
+checksum = "58e86c198e056d921b4f3f1d2755c23d090e942b5a70b03bcb7e7c02445aa491"
 dependencies = [
  "anyhow",
  "heck 0.5.0",
@@ -8472,7 +8466,7 @@ dependencies = [
 [[package]]
 name = "zksync_prover_interface"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-era.git#4d8862b76a55ac78edd481694fefd2107736ffd9"
+source = "git+https://github.com/matter-labs/zksync-era.git#946877f98d0448938a9c6030b0986346e5d93218"
 dependencies = [
  "chrono",
  "circuit_sequencer_api 0.150.4",
@@ -8487,7 +8481,7 @@ dependencies = [
 [[package]]
 name = "zksync_system_constants"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-era.git#4d8862b76a55ac78edd481694fefd2107736ffd9"
+source = "git+https://github.com/matter-labs/zksync-era.git#946877f98d0448938a9c6030b0986346e5d93218"
 dependencies = [
  "once_cell",
  "zksync_basic_types",
@@ -8497,7 +8491,7 @@ dependencies = [
 [[package]]
 name = "zksync_types"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-era.git#4d8862b76a55ac78edd481694fefd2107736ffd9"
+source = "git+https://github.com/matter-labs/zksync-era.git#946877f98d0448938a9c6030b0986346e5d93218"
 dependencies = [
  "anyhow",
  "bigdecimal 0.4.5",
@@ -8531,13 +8525,12 @@ dependencies = [
 [[package]]
 name = "zksync_utils"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-era.git#4d8862b76a55ac78edd481694fefd2107736ffd9"
+source = "git+https://github.com/matter-labs/zksync-era.git#946877f98d0448938a9c6030b0986346e5d93218"
 dependencies = [
  "anyhow",
  "bigdecimal 0.4.5",
  "futures",
  "hex",
- "itertools 0.10.5",
  "num",
  "once_cell",
  "reqwest 0.12.7",
@@ -8554,7 +8547,7 @@ dependencies = [
 [[package]]
 name = "zksync_vlog"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-era.git#4d8862b76a55ac78edd481694fefd2107736ffd9"
+source = "git+https://github.com/matter-labs/zksync-era.git#946877f98d0448938a9c6030b0986346e5d93218"
 dependencies = [
  "anyhow",
  "chrono",
@@ -8580,7 +8573,7 @@ dependencies = [
 [[package]]
 name = "zksync_vm_interface"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-era.git#4d8862b76a55ac78edd481694fefd2107736ffd9"
+source = "git+https://github.com/matter-labs/zksync-era.git#946877f98d0448938a9c6030b0986346e5d93218"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8596,7 +8589,7 @@ dependencies = [
 [[package]]
 name = "zksync_web3_decl"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync-era.git#4d8862b76a55ac78edd481694fefd2107736ffd9"
+source = "git+https://github.com/matter-labs/zksync-era.git#946877f98d0448938a9c6030b0986346e5d93218"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8604,7 +8597,7 @@ dependencies = [
  "jsonrpsee",
  "pin-project-lite",
  "rlp",
- "rustls 0.23.12",
+ "rustls 0.23.13",
  "serde",
  "serde_json",
  "thiserror",

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -64,7 +64,7 @@ pub async fn start() -> eyre::Result<()> {
     match command {
         ZKSyncCommand::Wallet(cmd) => cmd.run(cfg).await?,
         ZKSyncCommand::Chain(cmd) => cmd.run(cfg).await?,
-        ZKSyncCommand::Prover(cmd) => cmd.run()?,
+        ZKSyncCommand::Prover(cmd) => cmd.run(cfg).await?,
         ZKSyncCommand::Contract(cmd) => cmd.run(cfg)?,
         ZKSyncCommand::Contracts(cmd) => cmd.run(cfg).await?,
         ZKSyncCommand::Autocomplete(cmd) => cmd.run()?,

--- a/src/commands/prover.rs
+++ b/src/commands/prover.rs
@@ -1,6 +1,12 @@
+use crate::{config::ZKSyncConfig, utils::wallet::get_wallet_l1_l2_providers};
 use clap::Subcommand;
+use colored::Colorize;
+use spinoff::{spinners, Color, Spinner};
 use std::path::PathBuf;
-use zksync_ethers_rs::types::zksync::inputs::WitnessInputData;
+use zksync_ethers_rs::{
+    types::zksync::{api::L1BatchDetails, inputs::WitnessInputData, L1BatchNumber},
+    ZKMiddleware,
+};
 
 #[derive(Subcommand)]
 pub(crate) enum Command {
@@ -19,10 +25,18 @@ pub(crate) enum Command {
         #[arg(long, default_value = "false", requires = "file_path")]
         eip_4844_blobs: bool,
     },
+    #[clap(
+        about = "Prover - Batch Details. It gets the proof-time of the specified batch.",
+        visible_alias = "batch-details"
+    )]
+    BatchDetails {
+        #[clap(short = 'n', num_args = 1..)]
+        batches: Option<Vec<L1BatchNumber>>,
+    },
 }
 
 impl Command {
-    pub fn run(self) -> eyre::Result<()> {
+    pub async fn run(self, cfg: ZKSyncConfig) -> eyre::Result<()> {
         match self {
             Command::DebugWitnessInputs {
                 file_path,
@@ -51,7 +65,64 @@ impl Command {
                     }
                 }
             }
+            Command::BatchDetails { batches } => {
+                let (_, _, l2_provider) = get_wallet_l1_l2_providers(cfg)?;
+
+                let current_batch = l2_provider.get_l1_batch_number().await?.as_u32().into();
+
+                let batches_vec = if let Some(batches_vec) = batches {
+                    batches_vec
+                } else {
+                    vec![current_batch]
+                };
+
+                let msg = if batches_vec.len() > 1 {
+                    "Fetching Batches' Data"
+                } else {
+                    "Fetching Batch's Data"
+                };
+
+                let mut spinner = Spinner::new(spinners::Dots, msg, Color::Blue);
+
+                let mut batches_details = Vec::new();
+                for batch in batches_vec {
+                    if batch.0 > current_batch.0 {
+                        println!("Batch doesn't exist, Current batch: {}", current_batch.0);
+                        break;
+                    }
+                    batches_details.push(l2_provider.get_l1_batch_details(batch.0).await?);
+                }
+                spinner.success("Success");
+                display_batches_proof_time_from_details(batches_details);
+            }
         }
         Ok(())
+    }
+}
+
+fn display_batches_proof_time_from_details(batches_details: Vec<L1BatchDetails>) {
+    for batch_details in batches_details {
+        println!(
+            "{} {} {}",
+            "=".repeat(8),
+            format!("Batch {:0>5} Status", batch_details.number.0)
+                .bold()
+                .bright_cyan()
+                .on_black(),
+            "=".repeat(8)
+        );
+        if let Some(committed_at) = batch_details.base.committed_at {
+            println!("Committed At: {committed_at}");
+        }
+        if let Some(commit_tx_hash) = batch_details.base.commit_tx_hash {
+            println!("Commit Tx Hash: {commit_tx_hash:?}");
+        }
+
+        if let Some(proven_at) = batch_details.base.proven_at {
+            println!("Proven At: {proven_at}");
+        }
+        if let Some(prove_tx_hash) = batch_details.base.prove_tx_hash {
+            println!("Proven Tx Hash: {prove_tx_hash:?}");
+        }
     }
 }

--- a/src/commands/prover.rs
+++ b/src/commands/prover.rs
@@ -27,7 +27,7 @@ pub(crate) enum Command {
         eip_4844_blobs: bool,
     },
     #[clap(
-        about = "Prover - Batch Details. It gets the proof-time of the specified batch.",
+        about = "Prover - Batch Details. It gets the proof-time of the specified batch/es.",
         visible_alias = "batch-details"
     )]
     BatchDetails {


### PR DESCRIPTION
# Purpose
- It gives the provenAt and commitedAt timestamp
- There is a command that takes the db timestamps as reference (`zks db p proof-time`), but it seems to be off, and has to be checked.

## Usage

```
❯ zks prover batch-details --help
Prover - Batch Details. It gets the proof-time of the specified batch.

Usage: zks prover batch-details [OPTIONS]

Options:
  -n <BATCHES>...      
  -h, --help           Print help
```

