### PR TITLE
feat: load-test with contract interaction

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "nightly"
+channel = "nightly-2024-09-06"

--- a/src/utils/contract.rs
+++ b/src/utils/contract.rs
@@ -1,0 +1,95 @@
+// TODO
+// THIS FUNCTIONS SHOULD BE MIGRATED TO THE zksync_ethers_rs
+use eyre::ContextCompat;
+use zksync_ethers_rs::{
+    abi::Token,
+    core::utils::keccak256,
+    types::{Address, U256},
+};
+
+pub(crate) fn encode_call(
+    selector: Option<[u8; 4]>,
+    bytecode: Option<Vec<u8>>,
+    args: Option<Vec<String>>,
+    types: Option<Vec<String>>,
+) -> eyre::Result<Vec<u8>> {
+    let mut data = Vec::new();
+
+    if let Some(s) = selector {
+        data.extend_from_slice(&s);
+    } else if let Some(b) = bytecode {
+        data.extend_from_slice(&b);
+    }
+
+    let tokens = match (args, types) {
+        (Some(a), Some(t)) => {
+            if a.len() != t.len() {
+                return Err(eyre::eyre!("Argument count does not match type count"));
+            }
+            a.into_iter()
+                .zip(t.into_iter())
+                .map(|(arg, arg_type)| {
+                    match arg_type.as_str() {
+                        "address" => {
+                            // Parse as Address
+                            let address: Address = arg
+                                .parse()
+                                .map_err(|_e| eyre::eyre!("Invalid address format"))?;
+                            Ok(Token::Address(address))
+                        }
+                        "uint256" => {
+                            // Parse as uint256
+                            let value: U256 = U256::from_dec_str(&arg)
+                                .map_err(|_e| eyre::eyre!("Invalid uint256 format"))?;
+                            Ok(Token::Uint(value))
+                        }
+                        "string" => {
+                            // Parse as string
+                            Ok(Token::String(arg))
+                        }
+                        _ => Err(eyre::eyre!("Unsupported argument type")),
+                    }
+                })
+                .collect::<Result<Vec<Token>, eyre::Report>>()?
+        }
+        (Some(_), None) => {
+            return Err(eyre::eyre!("Types not provided"));
+        }
+        (None, _) => vec![],
+    };
+
+    let encoded_args = zksync_ethers_rs::abi::encode(&tokens);
+    data.extend(encoded_args);
+    Ok(data)
+}
+
+pub(crate) fn parse_signature(signature: &str) -> eyre::Result<Option<Vec<String>>> {
+    let mut types = Vec::new();
+
+    if let Some(start) = signature.find('(') {
+        if let Some(end) = signature.rfind(')') {
+            let params = signature.get(start + 1..end).context("Parsing Error")?;
+
+            // Split the parameters by comma
+            for param in params.split(',') {
+                let trimmed_param = param.trim();
+                types.push(trimmed_param.to_owned())
+            }
+        } else {
+            return Err(eyre::eyre!("Missing closing parenthesis in signature"));
+        }
+    } else {
+        return Err(eyre::eyre!("Missing opening parenthesis in signature"));
+    }
+    if types.is_empty() {
+        return Ok(None);
+    }
+    Ok(Some(types))
+}
+
+pub(crate) fn get_fn_selector(function_signature: &str) -> [u8; 4] {
+    let hash = keccak256(function_signature.as_bytes());
+    let mut selector = [0_u8; 4];
+    selector.copy_from_slice(&hash[0..4]);
+    selector
+}

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -8,6 +8,7 @@ use zksync_ethers_rs::{
 
 pub(crate) mod balance;
 pub(crate) mod config;
+pub(crate) mod contract;
 pub(crate) mod contracts;
 pub(crate) mod db;
 pub(crate) mod gas_tracker;

--- a/src/utils/test.rs
+++ b/src/utils/test.rs
@@ -58,8 +58,14 @@ pub async fn send_transactions(
     );
 
     while let Some(res) = set.join_next().await {
-        let tx_hash = res??;
-        l2_txs_receipts.push(tx_hash);
+        match res {
+            Ok(Ok(tx_hash)) => {
+                l2_txs_receipts.push(tx_hash);
+            }
+            Ok(Err(_)) | Err(_) => {
+                println!("Error in tx");
+            }
+        };
     }
     Ok(l2_txs_receipts)
 }
@@ -87,8 +93,14 @@ pub async fn send_transactions_back(
     }
 
     while let Some(res) = set.join_next().await {
-        let tx_hash = res??;
-        l2_txs_receipts.push(tx_hash);
+        match res {
+            Ok(Ok(tx_hash)) => {
+                l2_txs_receipts.push(tx_hash);
+            }
+            Ok(Err(_)) | Err(_) => {
+                println!("Error in tx");
+            }
+        };
     }
 
     println!(
@@ -367,10 +379,14 @@ pub(crate) async fn send_contract_transactions_for_test(
     }
 
     while let Some(res) = set.join_next().await {
-        let tx_hash = res??
-            .context("Error unwrapping transaction receipt")?
-            .transaction_hash;
-        l2_txs_receipts.push(tx_hash);
+        match res {
+            Ok(Ok(Some(tx_receipt))) => {
+                l2_txs_receipts.push(tx_receipt.transaction_hash);
+            }
+            Ok(Err(_)) | Err(_) | Ok(Ok(None)) => {
+                println!("Error in tx");
+            }
+        };
     }
     Ok(l2_txs_receipts)
 }


### PR DESCRIPTION
# Purpose
- Implement a `load-test` that generates multiple contract `send` transactions.
- Provide a quick solution to test the blockchain, all the test command can be condensed in a single command.

## Usage

The `StorageFibonacci` contract has to be deployed before running the command, and the `contract-address` is passes as parameter.

```
❯ zks test contract-interaction --help
LoadTest with contract interactions for the zkStack Chain.
Custom command, the contract is a simple fibonacci

Usage: zks test contract-interaction [OPTIONS] --tpr <TPR> --contract <CONTRACT_ADDRESS>

Options:
      --tpr <TPR>                    Transactions per run
  -c, --contract <CONTRACT_ADDRESS>  Contract Address, Make sure it follows the Custom Fibonacci Contract
  -r, --reruns <RERUNS_WANTED>       Amount of times to run the program in a loop, it defaults to 1. Max is 255 [default: 1]
  -h, --help                         Print help
```

## StorageFibonacci Contract

```solidity
// SPDX-License-Identifier: UNLICENSED
pragma solidity ^0.8.13;

contract StorageFibonacci {
    uint256 public storedData;

    function set(uint256 x) public {
        storedData = fibonacci(x);
    }

    function get() public view returns (uint256) {
        return storedData;
    }

    // Calculate Fibonacci
    // Cannot be accessed from outside the contract
    function fibonacci(uint256 x) internal pure returns (uint256) {
        if (x == 0) return 0;
        if (x == 1) return 1;

        uint256 a = 0;
        uint256 b = 1;
        uint256 c;

        for (uint256 i = 2; i <= x; i++) {
            c = a + b;
            a = b;
            b = c;
        }

        return b;
    }
}
```

> [!NOTE]
> The `zksync-cli` was used to deploy the contract because the rust sdk is in wip state
