### PR TITLE
refactor(batch-details): move logic into existing cmd

### DIFF
--- a/src/commands/chain.rs
+++ b/src/commands/chain.rs
@@ -229,26 +229,24 @@ impl Command {
                 println!("Confirmed Tokens: {confirmed_tokens:#?}");
             }
             Command::L1BatchDetails {
-                batches,
+                mut batches,
                 proof_time,
             } => {
                 let current_batch = l2_provider.get_l1_batch_number().await?.as_u32().into();
 
-                let batches_vec = if let Some(batches_vec) = batches {
-                    batches_vec
-                } else {
-                    vec![current_batch]
-                };
+                if batches.is_empty() {
+                    batches.push(current_batch);
+                }
 
                 if proof_time {
                     display_batches_proof_time_from_l1_batch_details(
-                        batches_vec,
+                        batches,
                         current_batch,
                         l2_provider,
                     )
                     .await?;
                 } else {
-                    display_batches_details(batches_vec, current_batch, l2_provider).await?;
+                    display_batches_details(batches, current_batch, l2_provider).await?;
                 }
             }
             Command::L2ToL1LogProof {

--- a/src/commands/chain.rs
+++ b/src/commands/chain.rs
@@ -43,7 +43,7 @@ pub(crate) enum Command {
         #[clap(
             short = 't',
             default_value_t = false,
-            help = "The command display the proof-time based on the L1 txs' timestamps, if this flag is not set, it will display the data in raw format."
+            help = "The command displays the proof-time based on the L1 txs' timestamps."
         )]
         proof_time: bool,
     },

--- a/src/commands/chain.rs
+++ b/src/commands/chain.rs
@@ -38,8 +38,8 @@ pub(crate) enum Command {
     },
     #[clap(about = "Retrieves details for a given L1 batch.")]
     L1BatchDetails {
-        #[clap(short = 'n', num_args = 1.., default_value_t = Vec::default)]
-        batches: Option<Vec<L1BatchNumber>>,
+        #[clap(short = 'n', num_args = 1..)]
+        batches: Vec<L1BatchNumber>,
         #[clap(
             short = 't',
             default_value_t = false,

--- a/src/commands/chain.rs
+++ b/src/commands/chain.rs
@@ -38,7 +38,7 @@ pub(crate) enum Command {
     },
     #[clap(about = "Retrieves details for a given L1 batch.")]
     L1BatchDetails {
-        #[clap(short = 'n', num_args = 1..)]
+        #[clap(short = 'n', num_args = 1.., default_value_t = Vec::default)]
         batches: Option<Vec<L1BatchNumber>>,
         #[clap(
             short = 't',

--- a/src/commands/chain.rs
+++ b/src/commands/chain.rs
@@ -2,6 +2,7 @@ use crate::{
     config::ZKSyncConfig,
     utils::{
         balance::{display_l1_balance, display_l2_balance},
+        chain::{display_batches_details, display_batches_proof_time_from_l1_batch_details},
         try_l1_provider_from_config, try_l2_provider_from_config,
     },
 };
@@ -12,7 +13,7 @@ use zksync_ethers_rs::{
     abi::Hash,
     core::utils::format_ether,
     providers::Middleware,
-    types::{Address, Bytes, U64},
+    types::{zksync::L1BatchNumber, Address, Bytes, U64},
     ZKMiddleware,
 };
 
@@ -36,7 +37,16 @@ pub(crate) enum Command {
         limit: u8,
     },
     #[clap(about = "Retrieves details for a given L1 batch.")]
-    L1BatchDetails { batch: u32 },
+    L1BatchDetails {
+        #[clap(short = 'n', num_args = 1..)]
+        batches: Option<Vec<L1BatchNumber>>,
+        #[clap(
+            short = 't',
+            default_value_t = false,
+            help = "The command display the proof-time based on the L1 txs' timestamps, if this flag is not set, it will display the data in raw format."
+        )]
+        proof_time: bool,
+    },
     L2ToL1LogProof {
         #[clap(long, name = "TRANSACTION_HASH")]
         transaction: Hash,
@@ -218,9 +228,28 @@ impl Command {
                 let confirmed_tokens = l2_provider.get_confirmed_tokens(from, limit).await?;
                 println!("Confirmed Tokens: {confirmed_tokens:#?}");
             }
-            Command::L1BatchDetails { batch } => {
-                let l1_batch_details = l2_provider.get_l1_batch_details(batch).await?;
-                println!("{l1_batch_details:#?}");
+            Command::L1BatchDetails {
+                batches,
+                proof_time,
+            } => {
+                let current_batch = l2_provider.get_l1_batch_number().await?.as_u32().into();
+
+                let batches_vec = if let Some(batches_vec) = batches {
+                    batches_vec
+                } else {
+                    vec![current_batch]
+                };
+
+                if proof_time {
+                    display_batches_proof_time_from_l1_batch_details(
+                        batches_vec,
+                        current_batch,
+                        l2_provider,
+                    )
+                    .await?;
+                } else {
+                    display_batches_details(batches_vec, current_batch, l2_provider).await?;
+                }
             }
             Command::L2ToL1LogProof {
                 transaction,

--- a/src/commands/prover.rs
+++ b/src/commands/prover.rs
@@ -1,13 +1,7 @@
-use crate::{config::ZKSyncConfig, utils::wallet::get_wallet_l1_l2_providers};
+use crate::config::ZKSyncConfig;
 use clap::Subcommand;
-use colored::Colorize;
-use spinoff::{spinners, Color, Spinner};
 use std::path::PathBuf;
-use zksync_ethers_rs::{
-    providers::{Http, Provider},
-    types::zksync::{inputs::WitnessInputData, L1BatchNumber},
-    ZKMiddleware,
-};
+use zksync_ethers_rs::types::zksync::inputs::WitnessInputData;
 
 #[derive(Subcommand)]
 pub(crate) enum Command {
@@ -26,18 +20,10 @@ pub(crate) enum Command {
         #[arg(long, default_value = "false", requires = "file_path")]
         eip_4844_blobs: bool,
     },
-    #[clap(
-        about = "Prover - Batch Details. It gets the proof-time of the specified batch/es.",
-        visible_alias = "batch-details"
-    )]
-    BatchDetails {
-        #[clap(short = 'n', num_args = 1..)]
-        batches: Option<Vec<L1BatchNumber>>,
-    },
 }
 
 impl Command {
-    pub async fn run(self, cfg: ZKSyncConfig) -> eyre::Result<()> {
+    pub async fn run(self, _cfg: ZKSyncConfig) -> eyre::Result<()> {
         match self {
             Command::DebugWitnessInputs {
                 file_path,
@@ -66,95 +52,7 @@ impl Command {
                     }
                 }
             }
-            Command::BatchDetails { batches } => {
-                let (_, _, l2_provider) = get_wallet_l1_l2_providers(cfg)?;
-
-                let current_batch = l2_provider.get_l1_batch_number().await?.as_u32().into();
-
-                let batches_vec = if let Some(batches_vec) = batches {
-                    batches_vec
-                } else {
-                    vec![current_batch]
-                };
-
-                display_batches_proof_time_from_l1_batch_details(
-                    batches_vec,
-                    current_batch,
-                    l2_provider,
-                )
-                .await?;
-            }
         }
         Ok(())
     }
-}
-
-async fn display_batches_proof_time_from_l1_batch_details(
-    batches: Vec<L1BatchNumber>,
-    current_batch: L1BatchNumber,
-    l2_provider: Provider<Http>,
-) -> eyre::Result<()> {
-    let msg = if batches.len() > 1 {
-        "Fetching Batches' Data"
-    } else {
-        "Fetching Batch's Data"
-    };
-
-    let mut spinner = Spinner::new(spinners::Dots, msg, Color::Blue);
-
-    let mut batches_details = Vec::new();
-    for batch in batches {
-        if batch.0 > current_batch.0 {
-            println!("Batch doesn't exist, Current batch: {}", current_batch.0);
-            break;
-        }
-        batches_details.push(l2_provider.get_l1_batch_details(batch.0).await?);
-    }
-    spinner.success("Success");
-    for batch_details in batches_details {
-        println!(
-            "{} {} {}",
-            "=".repeat(8),
-            format!("Batch {:0>5} Status", batch_details.number.0)
-                .bold()
-                .bright_cyan()
-                .on_black(),
-            "=".repeat(8)
-        );
-        if let Some(committed_at) = batch_details.base.committed_at {
-            println!("{}: {committed_at}", "Committed At".yellow());
-        }
-        if let Some(commit_tx_hash) = batch_details.base.commit_tx_hash {
-            println!(
-                "Commit Tx Hash: {}",
-                format!("{commit_tx_hash:?}").bright_blue()
-            );
-        }
-        if let Some(proven_at) = batch_details.base.proven_at {
-            println!("{}: {proven_at}", "Proven At".yellow());
-        }
-        if let Some(prove_tx_hash) = batch_details.base.prove_tx_hash {
-            println!(
-                "Proven Tx Hash: {}",
-                format!("{prove_tx_hash:?}").bright_blue()
-            );
-        }
-        if let (Some(committed_at), Some(proven_at)) = (
-            batch_details.base.committed_at,
-            batch_details.base.proven_at,
-        ) {
-            let duration = proven_at - committed_at;
-            let formatted_duration = format!(
-                "{:02}:{:02}:{:02}",
-                duration.num_hours(),
-                duration.num_minutes() % 60,
-                duration.num_seconds() % 60
-            );
-            println!(
-                "ProofTime from Committed to Proven: {}",
-                formatted_duration.on_black().green()
-            );
-        }
-    }
-    Ok(())
 }

--- a/src/utils/chain.rs
+++ b/src/utils/chain.rs
@@ -1,0 +1,115 @@
+use colored::Colorize;
+use spinoff::{spinners, Color, Spinner};
+use zksync_ethers_rs::{
+    providers::{Http, Provider},
+    types::zksync::L1BatchNumber,
+    ZKMiddleware,
+};
+
+pub(crate) async fn display_batches_proof_time_from_l1_batch_details(
+    batches: Vec<L1BatchNumber>,
+    current_batch: L1BatchNumber,
+    l2_provider: Provider<Http>,
+) -> eyre::Result<()> {
+    let msg = if batches.len() > 1 {
+        "Fetching Batches' Data"
+    } else {
+        "Fetching Batch's Data"
+    };
+
+    let mut spinner = Spinner::new(spinners::Dots, msg, Color::Blue);
+
+    let mut batches_details = Vec::new();
+    for batch in batches {
+        if batch.0 > current_batch.0 {
+            println!("Batch doesn't exist, Current batch: {}", current_batch.0);
+            break;
+        }
+        batches_details.push(l2_provider.get_l1_batch_details(batch.0).await?);
+    }
+    spinner.success("Data Retrieved");
+    for batch_details in batches_details {
+        println!(
+            "{} {} {}",
+            "=".repeat(8),
+            format!("Batch {:0>5} Status", batch_details.number.0)
+                .bold()
+                .bright_cyan()
+                .on_black(),
+            "=".repeat(8)
+        );
+        if let Some(committed_at) = batch_details.base.committed_at {
+            println!("{}: {committed_at}", "Committed At".yellow());
+        }
+        if let Some(commit_tx_hash) = batch_details.base.commit_tx_hash {
+            println!(
+                "Commit Tx Hash: {}",
+                format!("{commit_tx_hash:?}").bright_blue()
+            );
+        }
+        if let Some(proven_at) = batch_details.base.proven_at {
+            println!("{}: {proven_at}", "Proven At".yellow());
+        }
+        if let Some(prove_tx_hash) = batch_details.base.prove_tx_hash {
+            println!(
+                "Proven Tx Hash: {}",
+                format!("{prove_tx_hash:?}").bright_blue()
+            );
+        }
+        if let (Some(committed_at), Some(proven_at)) = (
+            batch_details.base.committed_at,
+            batch_details.base.proven_at,
+        ) {
+            let duration = proven_at - committed_at;
+            let formatted_duration = format!(
+                "{:02}:{:02}:{:02}",
+                duration.num_hours(),
+                duration.num_minutes() % 60,
+                duration.num_seconds() % 60
+            );
+            println!(
+                "ProofTime from Committed to Proven: {}",
+                formatted_duration.on_black().green()
+            );
+        }
+    }
+    Ok(())
+}
+
+pub(crate) async fn display_batches_details(
+    batches: Vec<L1BatchNumber>,
+    current_batch: L1BatchNumber,
+    l2_provider: Provider<Http>,
+) -> eyre::Result<()> {
+    let msg = if batches.len() > 1 {
+        "Fetching Batches' Data"
+    } else {
+        "Fetching Batch's Data"
+    };
+
+    let mut spinner = Spinner::new(spinners::Dots, msg, Color::Blue);
+
+    let mut batches_details = Vec::new();
+    for batch in batches {
+        if batch.0 > current_batch.0 {
+            println!("Batch doesn't exist, Current batch: {}", current_batch.0);
+            break;
+        }
+        batches_details.push(l2_provider.get_l1_batch_details(batch.0).await?);
+    }
+    spinner.success("Data Retrieved");
+    for batch_details in batches_details {
+        println!(
+            "{} {} {}",
+            "=".repeat(8),
+            format!("Batch {:0>5} Status", batch_details.number.0)
+                .bold()
+                .bright_cyan()
+                .on_black(),
+            "=".repeat(8)
+        );
+
+        println!("{batch_details:#?}");
+    }
+    Ok(())
+}

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -7,6 +7,7 @@ use zksync_ethers_rs::{
 };
 
 pub(crate) mod balance;
+pub(crate) mod chain;
 pub(crate) mod config;
 pub(crate) mod contract;
 pub(crate) mod contracts;


### PR DESCRIPTION
# Purpose
- Move the logic of `zks prover batch-details` into `zks chain l1-batch-details`

## Help msg

```
❯ zks chain l1-batch-details --help
Retrieves details for a given L1 batch.

Usage: zks chain l1-batch-details [OPTIONS]

Options:
  -n <BATCHES>...      
  -t                   The command displays the proof-time based on the L1 txs' timestamps.
  -h, --help           Print help
```

## Example

```
❯ zks chain l1-batch-details -t -n 55
✓ Success                         
======== Batch 00055 Status ========
Committed At: 2024-09-19 01:18:50.224044 UTC
Commit Tx Hash: 0xd1de5efc3b71b8538328f80b750b95fe3a0d9b887a00eb77c898da66dbf0aea9
Proven At: 2024-09-19 15:54:37.330386 UTC
Proven Tx Hash: 0xcbbaaeafecd3e12bf3fc64d54560110d34459c03689ba4f92ccd0eac301db0ad
ProofTime from Committed to Proven: 14:35:47
```